### PR TITLE
myGuide - Add tabs navigation to tours page.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "myguide-fe",
       "version": "1.0.0",
       "dependencies": {
+        "@react-navigation/bottom-tabs": "^6.3.3",
         "@react-navigation/native": "^6.0.12",
         "@react-navigation/native-stack": "^6.8.0",
         "@rneui/base": "^4.0.0-rc.6",
@@ -4318,6 +4319,51 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@react-native/polyfills/-/polyfills-2.0.0.tgz",
       "integrity": "sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ=="
+    },
+    "node_modules/@react-navigation/bottom-tabs": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-6.3.3.tgz",
+      "integrity": "sha512-S5obigsDAgRD7hmGauijNITI2jPm7N40IIIwdQjJhT9Y9vos8ycLOKMVU06mchU6sRGJC2xIkPderPiwAUVvDg==",
+      "dependencies": {
+        "@react-navigation/elements": "^1.3.5",
+        "color": "^4.2.3",
+        "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^6.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 3.0.0",
+        "react-native-screens": ">= 3.0.0"
+      }
+    },
+    "node_modules/@react-navigation/bottom-tabs/node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/@react-navigation/bottom-tabs/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@react-navigation/bottom-tabs/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/@react-navigation/core": {
       "version": "6.3.0",
@@ -15776,6 +15822,40 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@react-native/polyfills/-/polyfills-2.0.0.tgz",
       "integrity": "sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ=="
+    },
+    "@react-navigation/bottom-tabs": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-6.3.3.tgz",
+      "integrity": "sha512-S5obigsDAgRD7hmGauijNITI2jPm7N40IIIwdQjJhT9Y9vos8ycLOKMVU06mchU6sRGJC2xIkPderPiwAUVvDg==",
+      "requires": {
+        "@react-navigation/elements": "^1.3.5",
+        "color": "^4.2.3",
+        "warn-once": "^0.1.0"
+      },
+      "dependencies": {
+        "color": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+          "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+          "requires": {
+            "color-convert": "^2.0.1",
+            "color-string": "^1.9.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        }
+      }
     },
     "@react-navigation/core": {
       "version": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@react-navigation/bottom-tabs": "^6.3.3",
     "@react-navigation/native": "^6.0.12",
     "@react-navigation/native-stack": "^6.8.0",
     "@rneui/base": "^4.0.0-rc.6",

--- a/src/components/user/JoinTour.js
+++ b/src/components/user/JoinTour.js
@@ -2,15 +2,14 @@ import { Text, View } from "react-native";
 import {useEffect, useRef, useState} from 'react'
 import Map from './Map'
 import { Button } from "@rneui/themed";
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import SitesTab from './SitesTab'
+
+const Tab = createBottomTabNavigator();
 
 const JoinTour = ({route}) => {
   const tourId = route.params.tourId
   const [hasStarted, setHasStarted] = useState(false)
-
-  useEffect(() => {
-
-  }, [])
-
 
   const startTour = () => {
     setHasStarted(true)
@@ -23,11 +22,14 @@ const JoinTour = ({route}) => {
     </View>
   }
 
+  return  <Tab.Navigator>
+    <Tab.Screen name="Tour Map" component={Map} />
+    <Tab.Screen name="Tour Sites" component={SitesTab} />
+  </Tab.Navigator>
+
   return <View> 
   <Map tourId={tourId}/>
 </View>
-  
-
 };
 
 export default JoinTour;

--- a/src/components/user/SitesTab.js
+++ b/src/components/user/SitesTab.js
@@ -1,0 +1,7 @@
+import { Text } from "@rneui/themed"
+
+const SitesTab = () => {
+    return <Text>This is the sites tab</Text>
+}
+
+export default SitesTab


### PR DESCRIPTION
This PR completes ticket https://trello.com/c/9dvxJHhE/21-fe-jointour-create-nav-bar-to-change-between-map-and-sitestab

This branch adds:
- Installed the bottom-tabs module from react-native-navigation.
- Added the tabs to the tour screen to be able to flick between map and sites tab.