### PR TITLE
MyGuide PR 9: Implement Test data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@react-navigation/native-stack": "^6.8.0",
         "@rneui/base": "^4.0.0-rc.6",
         "@rneui/themed": "^4.0.0-rc.6",
+        "axios": "^0.27.2",
         "expo": "~46.0.9",
         "expo-location": "^14.3.0",
         "expo-status-bar": "~1.4.0",
@@ -4880,6 +4881,28 @@
         "node": ">= 4.5.0"
       }
     },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/babel-core": {
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
@@ -6916,6 +6939,25 @@
       "integrity": "sha512-1gIBiWJNR0tKUNv8gZuk7l9rVX06OuLzY9AoGio7y/JT4V1IZErEMEq2TJS+PFcw/y0RshZ1J/27VfK1UQzYVg==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/fontfaceobserver": {
@@ -16269,6 +16311,27 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "babel-core": {
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
@@ -17865,6 +17928,11 @@
       "version": "0.121.0",
       "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.121.0.tgz",
       "integrity": "sha512-1gIBiWJNR0tKUNv8gZuk7l9rVX06OuLzY9AoGio7y/JT4V1IZErEMEq2TJS+PFcw/y0RshZ1J/27VfK1UQzYVg=="
+    },
+    "follow-redirects": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
     },
     "fontfaceobserver": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@react-navigation/native-stack": "^6.8.0",
     "@rneui/base": "^4.0.0-rc.6",
     "@rneui/themed": "^4.0.0-rc.6",
+    "axios": "^0.27.2",
     "expo": "~46.0.9",
     "expo-location": "^14.3.0",
     "expo-status-bar": "~1.4.0",

--- a/src/components/user/JoinTour.js
+++ b/src/components/user/JoinTour.js
@@ -12,11 +12,14 @@ const JoinTour = ({route}) => {
   const tourId = route.params.tourId
   const [hasStarted, setHasStarted] = useState(false)
   const [tour, setTour] = useState({})
+  const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
+
     const getTour = async () => {
       const tour = await getTourById(tourId)
       setTour(tour);
+      setIsLoading(false)
     }
     getTour()
   }, [])
@@ -26,6 +29,13 @@ const JoinTour = ({route}) => {
   }
   
   const {tourCode, tourName, tourDescription, tourImage} = tour;
+
+  while(isLoading){
+    return <>
+      <Text>Tour Loading...</Text>
+      <Button loading></Button>
+    </>
+  }
 
   while(!hasStarted){
     return <View style={{alignItems: 'center', textAlign: 'center'}}>
@@ -39,7 +49,7 @@ const JoinTour = ({route}) => {
 
   return  <Tab.Navigator>
     <Tab.Screen name="Tour Map" children={()=><Map tourData={tour} />}/>
-    <Tab.Screen name="Tour Sites" component={SitesTab} />
+    <Tab.Screen name="Tour Sites" children={()=><SitesTab tourData={tour} />} />
   </Tab.Navigator>
 };
 

--- a/src/components/user/JoinTour.js
+++ b/src/components/user/JoinTour.js
@@ -37,6 +37,10 @@ const JoinTour = ({route}) => {
     </>
   }
 
+  if(typeof tour === 'string'){
+    return <Text>{tour}</Text>
+  }
+
   while(!hasStarted){
     return <View style={{alignItems: 'center', textAlign: 'center'}}>
     <Text style={{fontSize: 50}}>{tourName}</Text>

--- a/src/components/user/JoinTour.js
+++ b/src/components/user/JoinTour.js
@@ -1,35 +1,46 @@
+import {useEffect, useState} from 'react'
 import { Text, View } from "react-native";
-import {useEffect, useRef, useState} from 'react'
-import Map from './Map'
-import { Button } from "@rneui/themed";
+import { Button, Image } from "@rneui/themed";
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import SitesTab from './SitesTab'
+import Map from './Map'
+import { getTourById } from "../../utils/api";
 
 const Tab = createBottomTabNavigator();
 
 const JoinTour = ({route}) => {
   const tourId = route.params.tourId
   const [hasStarted, setHasStarted] = useState(false)
+  const [tour, setTour] = useState({})
+
+  useEffect(() => {
+    const getTour = async () => {
+      const tour = await getTourById(tourId)
+      setTour(tour);
+    }
+    getTour()
+  }, [])
 
   const startTour = () => {
     setHasStarted(true)
   }
+  
+  const {tourCode, tourName, tourDescription, tourImage} = tour;
 
   while(!hasStarted){
-    return <View style={{alignItems: 'center'}}> 
-    <Text style={{fontSize: 50, textAlign: 'center'}}>Do you want to take tour {tourId}?</Text>
+    return <View style={{alignItems: 'center', textAlign: 'center'}}>
+    <Text style={{fontSize: 50}}>{tourName}</Text>
+    <Image source={{uri:tourImage}} style={{height: 200, width: 300}}></Image>
+    <Text> Tour code: {tourCode}</Text>
+    <Text>{tourDescription}</Text>
     <Button onPress={startTour}>Start Tour</Button>
     </View>
   }
 
   return  <Tab.Navigator>
-    <Tab.Screen name="Tour Map" component={Map} />
+    <Tab.Screen name="Tour Map" children={()=><Map tourData={tour} />}/>
     <Tab.Screen name="Tour Sites" component={SitesTab} />
   </Tab.Navigator>
-
-  return <View> 
-  <Map tourId={tourId}/>
-</View>
 };
 
 export default JoinTour;

--- a/src/components/user/Map.js
+++ b/src/components/user/Map.js
@@ -8,8 +8,6 @@ import { getSitesByTour } from '../../utils/api'
 
 const Map = ({tourData}) => {
   const [errorMsg, setErrorMsg] = useState(null)
-  // const [latitude, setLatitude] = useState(0)
-  // const [longitude, setLongitude] = useState(0)
   const [isLoading, setIsLoading] = useState(true)
   const [tourMarkers, setTourMarkers] = useState()
 
@@ -20,9 +18,6 @@ const Map = ({tourData}) => {
         setErrorMsg("Permission to access location was denied. Please enable location data.")
         return
       }
-    //   let currentPosition = await Location.getCurrentPositionAsync({})
-    //   setLatitude(currentPosition.coords.latitude)
-    //   setLongitude(currentPosition.coords.longitude)
       populateTourMarkers()
     }
 

--- a/src/components/user/Map.js
+++ b/src/components/user/Map.js
@@ -4,9 +4,9 @@ import MapView, { PROVIDER_GOOGLE } from "react-native-maps"
 import { View, Text } from "react-native"
 import * as Location from "expo-location"
 import { Marker } from "react-native-maps"
-import { getSitesById } from '../../utils/api'
+import { getSitesByTour } from '../../utils/api'
 
-const Map = ({tourId}) => {
+const Map = ({tourData}) => {
   const [errorMsg, setErrorMsg] = useState(null)
   // const [latitude, setLatitude] = useState(0)
   // const [longitude, setLongitude] = useState(0)
@@ -27,7 +27,7 @@ const Map = ({tourId}) => {
     }
 
     const populateTourMarkers = async () => {
-      const tourSites = await getSitesById();
+      const tourSites = await getSitesByTour(tourData.tourSites);
       setTourMarkers(tourSites)
       setIsLoading(false)
     }
@@ -38,7 +38,7 @@ const Map = ({tourId}) => {
   if (errorMsg) return <Text>{errorMsg}</Text>
 
   while(isLoading){
-    return <Text>Joining {tourId}</Text>
+    return <Text>Joining {tourData.tourName}</Text>
   }  
 
   return <>

--- a/src/components/user/Map.js
+++ b/src/components/user/Map.js
@@ -4,32 +4,42 @@ import MapView, { PROVIDER_GOOGLE } from "react-native-maps"
 import { View, Text } from "react-native"
 import * as Location from "expo-location"
 import { Marker } from "react-native-maps"
+import { getSitesById } from '../../utils/api'
 
 const Map = ({tourId}) => {
   const [errorMsg, setErrorMsg] = useState(null)
-  const [latitude, setLatitude] = useState(0)
-  const [longitude, setLongitude] = useState(0)
+  // const [latitude, setLatitude] = useState(0)
+  // const [longitude, setLongitude] = useState(0)
   const [isLoading, setIsLoading] = useState(true)
+  const [tourMarkers, setTourMarkers] = useState()
 
   useEffect(() => {
-    (async () => {
+    const setUserLocation = async () => {
       let { status } = await Location.requestForegroundPermissionsAsync()
       if (status !== "granted") {
         setErrorMsg("Permission to access location was denied. Please enable location data.")
         return
       }
-      let currentPosition = await Location.getCurrentPositionAsync({})
-      setLatitude(currentPosition.coords.latitude)
-      setLongitude(currentPosition.coords.longitude)
+    //   let currentPosition = await Location.getCurrentPositionAsync({})
+    //   setLatitude(currentPosition.coords.latitude)
+    //   setLongitude(currentPosition.coords.longitude)
+      populateTourMarkers()
+    }
+
+    const populateTourMarkers = async () => {
+      const tourSites = await getSitesById();
+      setTourMarkers(tourSites)
       setIsLoading(false)
-    })()
+    }
+
+    setUserLocation()
   }, [])
   
   if (errorMsg) return <Text>{errorMsg}</Text>
 
   while(isLoading){
     return <Text>Joining {tourId}</Text>
-  }
+  }  
 
   return <>
   <View style={styles.mapContainer}>
@@ -40,12 +50,20 @@ const Map = ({tourId}) => {
       showsBuildings={false}
       provider={PROVIDER_GOOGLE}
       initialRegion={{
-        latitude: latitude,
-        longitude: longitude,
+        latitude: tourMarkers[0].latitude,
+        longitude: tourMarkers[0].longitude,
         latitudeDelta: 0.0922,
         longitudeDelta: 0.0421
       }}
     >
+    {tourMarkers.map(({siteId, siteName, siteDescription, latitude, longitude}) => {
+      return <Marker 
+        key={siteId}
+        coordinate={{latitude, longitude}}
+        title={siteName}
+        description={siteDescription}
+      />
+    })}
     </MapView>
   </View>
   </>

--- a/src/components/user/SitesTab.js
+++ b/src/components/user/SitesTab.js
@@ -1,5 +1,6 @@
-import { Icon, Text, ListItem } from "@rneui/themed"
+import { Icon, Text, ListItem, Image } from "@rneui/themed"
 import { useEffect, useState } from "react";
+import { Linking } from "react-native";
 import { getSitesById } from "../../utils/api";
 
 const SitesTab = ({tourData: {tourSites}}) => {
@@ -18,12 +19,17 @@ const SitesTab = ({tourData: {tourSites}}) => {
     }, [])
 
     if(isLoading) return <Text>Loading sites...</Text>
-    
     return siteInfo.map(({siteId, siteName, siteDescription, siteImage, siteAddress, contactInfo, websiteLink}) => (
         <ListItem key={siteId} bottomDivider>
+                <Image source={{uri:siteImage}} style={{height: 100, width: 100}}/>
                 <ListItem.Content>
                 <ListItem.Title>{siteName}</ListItem.Title>
-                <ListItem.Subtitle><Text>{siteDescription}</Text></ListItem.Subtitle>
+                <Text>{siteDescription}</Text>
+                <Text>{siteAddress}</Text>
+                <Text>{contactInfo}</Text>
+                <Text style={{color: 'blue'}} onPress={() => Linking.openURL(websiteLink)}>
+                    Visit Website
+                </Text>
                 </ListItem.Content>
             </ListItem>
     ))

--- a/src/components/user/SitesTab.js
+++ b/src/components/user/SitesTab.js
@@ -1,7 +1,31 @@
-import { Text } from "@rneui/themed"
+import { Icon, Text, ListItem } from "@rneui/themed"
+import { useEffect, useState } from "react";
+import { getSitesById } from "../../utils/api";
 
-const SitesTab = () => {
-    return <Text>This is the sites tab</Text>
+const SitesTab = ({tourData: {tourSites}}) => {
+
+    const [siteInfo, setSiteInfo] = useState()
+    const [isLoading, setIsLoading] = useState(true)
+    const [expanded, setExpanded] = useState({})
+    
+    useEffect(() => {
+        const getSiteInfo = async () => {
+            const tourSites = await getSitesById();
+            setSiteInfo(tourSites)
+            setIsLoading(false)
+            }
+        getSiteInfo()
+    }, [])
+
+    if(isLoading) return <Text>Loading sites...</Text>
+    
+    return siteInfo.map(({siteId, siteName, siteDescription, siteImage, siteAddress, contactInfo, websiteLink}) => (
+        <ListItem key={siteId} bottomDivider>
+                <ListItem.Content>
+                <ListItem.Title>{siteName}</ListItem.Title>
+                <ListItem.Subtitle><Text>{siteDescription}</Text></ListItem.Subtitle>
+                </ListItem.Content>
+            </ListItem>
+    ))
 }
-
 export default SitesTab

--- a/src/components/user/SitesTab.js
+++ b/src/components/user/SitesTab.js
@@ -1,9 +1,9 @@
 import { Icon, Text, ListItem, Image } from "@rneui/themed"
 import { useEffect, useState } from "react";
 import { Linking } from "react-native";
-import { getSitesById } from "../../utils/api";
+import { getSitesByTour } from "../../utils/api";
 
-const SitesTab = ({tourData: {tourSites}}) => {
+const SitesTab = ({tourData}) => {
 
     const [siteInfo, setSiteInfo] = useState()
     const [isLoading, setIsLoading] = useState(true)
@@ -11,7 +11,7 @@ const SitesTab = ({tourData: {tourSites}}) => {
     
     useEffect(() => {
         const getSiteInfo = async () => {
-            const tourSites = await getSitesById();
+            const tourSites = await getSitesByTour(tourData.tourSites);
             setSiteInfo(tourSites)
             setIsLoading(false)
             }

--- a/src/components/user/SitesTab.js
+++ b/src/components/user/SitesTab.js
@@ -7,7 +7,6 @@ const SitesTab = ({tourData}) => {
 
     const [siteInfo, setSiteInfo] = useState()
     const [isLoading, setIsLoading] = useState(true)
-    const [expanded, setExpanded] = useState({})
     
     useEffect(() => {
         const getSiteInfo = async () => {

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,0 +1,13 @@
+import axios from "axios";
+
+export const getTourById = async (tourId) => {
+    const {data} = await axios.get(`https://myguidebackend.onrender.com/tours`)
+    //DELETE THIS ONCE TOUR CODE IS QUERYABLE
+    return data[0]
+}
+
+export const getSitesById = async () => {
+    const {data} = await axios.get(`https://myguidebackend.onrender.com/sites`)
+    //DELETE THIS ONCE SITE ID IS QUERYABLE
+    return data
+}

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -3,11 +3,11 @@ import axios from "axios";
 export const getTourById = async (tourId) => {
     const {data} = await axios.get(`https://myguidebackend.onrender.com/tours`)
     //DELETE THIS ONCE TOUR CODE IS QUERYABLE
-    return data[0]
+    return tourId == 123456 ? data[0] 
+    : tourId == 654321 ? data[1] : `Sorry, ${tourId} has not been found`
 }
 
-export const getSitesById = async () => {
-    const {data} = await axios.get(`https://myguidebackend.onrender.com/sites`)
-    //DELETE THIS ONCE SITE ID IS QUERYABLE
+export const getSitesByTour = async (siteArray) => {
+    const {data} = await axios.get(`https://myguidebackend.onrender.com/sites`, {params: {site_ids: [siteArray]}})
     return data
 }


### PR DESCRIPTION
This PR completes tickets;
https://trello.com/c/1tOuq8KO/16-fe-map-display-sites-on-map
https://trello.com/c/bYGj34Yu/17-fe-sitestab-list-sites-on-current-tour

**This branch adds:**

**API File**
- Axios to make HTTP requests from the server.
- Extra API file in utils folder to encapsulate HTTP logic.
- Query to return an array of site lists.
- Hardcode some logic to filter out valid but non-existent tour code.

_Integrate tour code queries properly once it has been added to server backend_

**Map Markers**
- Added map markers to the map, generated by the list of sites on the tour. 
- When Marker is clicked, pops up a name of the place and a brief preview description.

**Site List Screen**
- Lists all sites on the tour with a picture, all the associated data and a hyperlink to the website

**This Branch Changes:**
**Confirmation Screen**
- Loading message and button whilst API is called.
- Tour data now loads into confirmation screen if correct tour code is input.

**Map**
- The map now loads initially on the first pin of the tour, instead of user location.
- Removed redundant code.

- All API calls for sites on map and site list are now are grabbed to utilise the tourSite array on the relevent tour object, instead of querying the sites endpoint.