### PR TITLE
MyGuide PR #11: add site cards to all markers

### DIFF
--- a/src/components/user/JoinTour.js
+++ b/src/components/user/JoinTour.js
@@ -13,6 +13,8 @@ const JoinTour = ({route}) => {
   const [hasStarted, setHasStarted] = useState(false)
   const [tour, setTour] = useState({})
   const [isLoading, setIsLoading] = useState(true)
+  const [userLatitude, setUserLatitude] = useState(null)
+  const [userLongitude, setUserLongitude] = useState(null)
 
   useEffect(() => {
 
@@ -52,8 +54,8 @@ const JoinTour = ({route}) => {
   }
 
   return  <Tab.Navigator>
-    <Tab.Screen name="Tour Map" children={()=><Map tourData={tour} />}/>
-    <Tab.Screen name="Tour Sites" children={()=><SitesTab tourData={tour} />} />
+    <Tab.Screen name="Tour Map" children={()=><Map tourData={tour} setUserLatitude={setUserLatitude} setUserLongitude={setUserLongitude}/>}/>
+    <Tab.Screen name="Tour Sites" children={()=><SitesTab tourData={tour} userLatitude={userLatitude} userLongitude={userLongitude}/>} />
   </Tab.Navigator>
 };
 

--- a/src/components/user/Map.js
+++ b/src/components/user/Map.js
@@ -5,11 +5,14 @@ import { View, Text } from "react-native"
 import * as Location from "expo-location"
 import { Marker } from "react-native-maps"
 import { getSitesByTour } from '../../utils/api'
+import SiteCard from './SiteCard'
 
-const Map = ({tourData}) => {
+const Map = ({tourData, setUserLatitude, setUserLongitude}) => {
   const [errorMsg, setErrorMsg] = useState(null)
   const [isLoading, setIsLoading] = useState(true)
   const [tourMarkers, setTourMarkers] = useState()
+  const [site, setSite] = useState()
+  const [visible, setVisible] = useState(false)
 
   useEffect(() => {
     const setUserLocation = async () => {
@@ -34,7 +37,13 @@ const Map = ({tourData}) => {
 
   while(isLoading){
     return <Text>Joining {tourData.tourName}</Text>
-  }  
+  }
+
+  const getSiteCard = (event) => {
+    const siteMarker = event.target._internalFiberInstanceHandleDEV.memoizedProps.site
+    setSite(siteMarker)
+    setVisible(!visible);
+  }
 
   return <>
   <View style={styles.mapContainer}>
@@ -51,15 +60,19 @@ const Map = ({tourData}) => {
         longitudeDelta: 0.0421
       }}
     >
-    {tourMarkers.map(({siteId, siteName, siteDescription, latitude, longitude}) => {
+    {tourMarkers.map((site) => {
+      const {siteId, siteName, siteDescription, latitude, longitude} = site;
       return <Marker 
         key={siteId}
+        site={site}
         coordinate={{latitude, longitude}}
         title={siteName}
         description={siteDescription}
+        onPress={getSiteCard}
       />
     })}
     </MapView>
+    <SiteCard visible={visible} setVisible={setVisible} getSiteCard={getSiteCard} site={site}/>
   </View>
   </>
 }

--- a/src/components/user/SiteCard.js
+++ b/src/components/user/SiteCard.js
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { Button, Overlay, Icon, Image, Divider } from '@rneui/themed';
+import { View, Text, StyleSheet } from 'react-native';
+
+const SiteCard = ({visible, setVisible, site}) => {
+
+if(!site) return
+const {siteId, siteName, siteDescription, siteImage, siteAddress, contactInfo, websiteLink} = site
+
+const toggleOverlay = () => {
+  setVisible(!visible);
+};
+
+return <Overlay isVisible={visible} onBackdropPress={toggleOverlay}>
+        <Image source={{uri:siteImage}} style={{height: 200, width: 300}}/>
+        <Text style={styles.textPrimary}>{siteName}</Text>
+        <Divider />
+        <Text>{siteDescription}</Text>
+        <Text>{siteAddress}</Text>
+        <Text>{contactInfo}</Text>
+        <Text style={{color: 'blue'}} onPress={() => Linking.openURL(websiteLink)}>
+            Visit Website
+        </Text>
+        <Button onPress={toggleOverlay}>
+        <Icon name='back' type="entypo"/>
+        </Button>
+    </Overlay>
+}
+
+export default SiteCard
+
+const styles = StyleSheet.create({
+    button: {
+      margin: 10,
+    },
+    textPrimary: {
+      marginVertical: 20,
+      textAlign: 'center',
+      fontSize: 20,
+    },
+    textSecondary: {
+      marginBottom: 10,
+      textAlign: 'center',
+      fontSize: 17,
+    },
+    });


### PR DESCRIPTION
This pull request completes ticket: https://trello.com/c/jKQ68zmU/18-fe-sitecard-display-pop-up-with-site-info

**This branch adds:**

**Site Cards**
- Site card component that displays an overlay with the site information.
- Triggers overlay on marker press, saving the markers site in state, then passing down to the siteCard component to render.

**Site Card**

<img src="https://user-images.githubusercontent.com/48326572/189141558-d3e5c258-b2f2-41a0-b61c-f396ffb06164.jpg" alt="Site Card" height="1000px">
